### PR TITLE
homepage page examples scale up effect

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -159,81 +159,81 @@
                 </div>
                 <div class="row mb-5">
                     <div class="col-6 mb-5">
-                        <a href="./pages/dashboard/dashboard.html" class="page-preview page-preview-lg scale-up-hover-2">
+                        <a href="./pages/dashboard/dashboard.html" class="page-preview scale-up-2">
                             <img class="shadow-lg rounded scale" src="./assets/img/pages/overview.jpg" alt="Dashboard page preview">
-                            <div class="text-center show-on-hover">
+                            <div class="text-center show-on-hover rounded-bottom">
                                 <h6 class="m-0 text-center text-white">Overview <i class="fas fa-external-link-alt ms-2"></i></h6>
                             </div>
                         </a>
                     </div>
                     <div class="col-6 mb-5">
-                        <a href="./pages/transactions.html" class="page-preview page-preview-lg scale-up-hover-2">
+                        <a href="./pages/transactions.html" class="page-preview scale-up-2">
                             <img class="shadow-lg rounded scale" src="./assets/img/pages/transactions.jpg" alt="Transactions page preview">
-                            <div class="text-center show-on-hover">
+                            <div class="text-center show-on-hover rounded-bottom">
                                 <h6 class="m-0 text-center text-white">Transactions <i class="fas fa-external-link-alt ms-2"></i></h6>
                             </div>
                         </a>
                     </div>
                     <div class="col-6 mb-5">
-                        <a href="./pages/settings.html" class="page-preview page-preview-lg scale-up-hover-2">
+                        <a href="./pages/settings.html" class="page-preview scale-up-2">
                             <img class="shadow-lg rounded scale" src="./assets/img/pages/settings.jpg" alt="Settings page preview">
-                            <div class="text-center show-on-hover">
+                            <div class="text-center show-on-hover rounded-bottom">
                                 <h6 class="m-0 text-center text-white">Settings <i class="fas fa-external-link-alt ms-2"></i></h6>
                             </div>
                         </a>
                     </div>
                     <div class="col-6 mb-5">
-                        <a href="./pages/examples/sign-in.html" class="page-preview page-preview-lg scale-up-hover-2">
+                        <a href="./pages/examples/sign-in.html" class="page-preview scale-up-2">
                             <img class="shadow-lg rounded scale" src="./assets/img/pages/sign-in.jpg" alt="Sign In page preview">
-                            <div class="text-center show-on-hover">
+                            <div class="text-center show-on-hover rounded-bottom">
                                 <h6 class="m-0 text-center text-white">Sign In <i class="fas fa-external-link-alt ms-2"></i></h6>
                             </div>
                         </a>
                     </div>
                     <div class="col-6 mb-5">
-                        <a href="./pages/examples/sign-up.html" class="page-preview page-preview-lg scale-up-hover-2">
+                        <a href="./pages/examples/sign-up.html" class="page-preview scale-up-2">
                             <img class="shadow-lg rounded scale" src="./assets/img/pages/sign-up.jpg" alt="Sign Up page preview">
-                            <div class="text-center show-on-hover">
+                            <div class="text-center show-on-hover rounded-bottom">
                                 <h6 class="m-0 text-center text-white">Sign Up <i class="fas fa-external-link-alt ms-2"></i></h6>
                             </div>
                         </a>
                     </div>
                     <div class="col-6 mb-5">
-                        <a href="./pages/examples/lock.html" class="page-preview page-preview-lg scale-up-hover-2">
+                        <a href="./pages/examples/lock.html" class="page-preview scale-up-2">
                             <img class="shadow-lg rounded scale" src="./assets/img/pages/lock.jpg" alt="Lock page preview">
-                            <div class="text-center show-on-hover">
+                            <div class="text-center show-on-hover rounded-bottom">
                                 <h6 class="m-0 text-center text-white">Sign Up <i class="fas fa-external-link-alt ms-2"></i></h6>
                             </div>
                         </a>
                     </div>
                     <div class="col-6 mb-5">
-                        <a href="./pages/examples/forgot-password.html" class="page-preview page-preview-lg scale-up-hover-2">
+                        <a href="./pages/examples/forgot-password.html" class="page-preview scale-up-2">
                             <img class="shadow-lg rounded scale" src="./assets/img/pages/forgot-password.jpg" alt="Forgot password preview">
-                            <div class="text-center show-on-hover">
+                            <div class="text-center show-on-hover rounded-bottom">
                                 <h6 class="m-0 text-center text-white">Forgot password <i class="fas fa-external-link-alt ms-2"></i></h6>
                             </div>
                         </a>
                     </div>
                     <div class="col-6 mb-5">
-                        <a href="./pages/examples/reset-password.html" class="page-preview page-preview-lg scale-up-hover-2">
+                        <a href="./pages/examples/reset-password.html" class="page-preview scale-up-2">
                             <img class="shadow-lg rounded scale" src="./assets/img/pages/reset-password.jpg" alt="Reset password preview">
-                            <div class="text-center show-on-hover">
+                            <div class="text-center show-on-hover rounded-bottom">
                                 <h6 class="m-0 text-center text-white">Reset password <i class="fas fa-external-link-alt ms-2"></i></h6>
                             </div>
                         </a>
                     </div>
                     <div class="col-6 mb-5">
-                        <a href="./pages/examples/404.html" class="page-preview page-preview-lg scale-up-hover-2">
+                        <a href="./pages/examples/404.html" class="page-preview scale-up-2">
                             <img class="shadow-lg rounded scale" src="./assets/img/pages/404.jpg" alt="404 error preview">
-                            <div class="text-center show-on-hover">
+                            <div class="text-center show-on-hover rounded-bottom">
                                 <h6 class="m-0 text-center text-white">404 <i class="fas fa-external-link-alt ms-2"></i></h6>
                             </div>
                         </a>
                     </div>
                     <div class="col-6 mb-5">
-                        <a href="./pages/examples/500.html" class="page-preview page-preview-lg scale-up-hover-2">
+                        <a href="./pages/examples/500.html" class="page-preview scale-up-2">
                             <img class="shadow-lg rounded scale" src="./assets/img/pages/500.jpg" alt="500 error preview">
-                            <div class="text-center show-on-hover">
+                            <div class="text-center show-on-hover rounded-bottom">
                                 <h6 class="m-0 text-center text-white">500 <i class="fas fa-external-link-alt ms-2"></i></h6>
                             </div>
                         </a>

--- a/src/scss/volt/components/_card.scss
+++ b/src/scss/volt/components/_card.scss
@@ -85,28 +85,19 @@
 
     .show-on-hover {
         position: absolute;
-        bottom: -25px;
+        bottom: -0;
         background: rgba($dark, .85);
         padding: 10px 0;
-        border-bottom-left-radius: 1.5rem;
-        border-bottom-right-radius:1.5rem;
-        width: calc(100% + 28px);
-        left: -14px;
+        width: 100%;
+        left: 0;
         opacity: 0;
         @include transition(.2s);
     }
 
-    &.page-preview-lg {
-        .show-on-hover {
-            left: -30px;
-            width: calc(100% + 60px);
-            bottom: -20px;
-        }
-    }
-
     &:hover {
+        z-index: 1;
+        
         .show-on-hover {
-            z-index: 99;
             opacity: 1;
         }
     }


### PR DESCRIPTION
Tweak homepage page examples html/css so scale up effect is on top of sibling element and link is rounded like image. Used existing classes and made more future-proof. 