### PR TITLE
Replace divisions with equivalent multiplication

### DIFF
--- a/src/scss/volt/_variables.scss
+++ b/src/scss/volt/_variables.scss
@@ -308,8 +308,8 @@ $gradient: linear-gradient(180deg, rgba($white, .15), rgba($white, 0)) !default;
 
 $spacer: 1rem !default;
 $spacers: (0: 0,
-    1: $spacer / 4,
-    2: $spacer / 2,
+    1: $spacer * 0.25,
+    2: $spacer * 0.5,
     3: $spacer,
     4: $spacer * 1.5,
     5: $spacer * 3,
@@ -501,7 +501,7 @@ $h4-font-size: $font-size-base * 1.5 !default;
 $h5-font-size: $font-size-base * 1.25 !default;
 $h6-font-size: $font-size-base !default;
 
-$headings-margin-bottom: $spacer / 2 !default;
+$headings-margin-bottom: $spacer * 0.5 !default;
 $headings-font-family  : null !default;
 $headings-font-style   : null !default;
 $headings-font-weight  : $font-weight-bold !default;
@@ -796,7 +796,7 @@ $input-height-border: $input-border-width * 2 !default;
 
 $input-height-inner        : add($input-line-height * 1em, $input-padding-y * 2) !default;
 $input-height-inner-half   : add($input-line-height * .5em, $input-padding-y) !default;
-$input-height-inner-quarter: add($input-line-height * .25em, $input-padding-y / 2) !default;
+$input-height-inner-quarter: add($input-line-height * .25em, $input-padding-y * 0.5) !default;
 
 $input-height   : add($input-line-height * 1em, add($input-padding-y * 2, $input-height-border, false)) !default;
 $input-height-sm: add($input-line-height * 1em, add($input-padding-y-sm * 2, $input-height-border, false)) !default;
@@ -1187,7 +1187,7 @@ $dropdown-border-radius      : $border-radius-sm !default;
 $dropdown-border-width       : $border-width !default;
 $dropdown-inner-border-radius: subtract($dropdown-border-radius, $dropdown-border-width) !default;
 $dropdown-divider-bg         : $gray-200 !default;
-$dropdown-divider-margin-y   : $spacer / 2 !default;
+$dropdown-divider-margin-y   : $spacer * 0.5 !default;
 $dropdown-box-shadow         : 0 10px 15px -3px rgba(0, 0, 0, 0.1),0 4px 6px -2px rgba(0, 0, 0, 0.05) !default;
 
 $dropdown-link-color      : $gray-900 !default;
@@ -1199,7 +1199,7 @@ $dropdown-link-active-bg   : $gray-200 !default;
 
 $dropdown-link-disabled-color: $gray-600 !default;
 
-$dropdown-item-padding-y: $spacer / 4 !default;
+$dropdown-item-padding-y: $spacer * 0.5 !default;
 $dropdown-item-padding-x: $spacer !default;
 
 $dropdown-header-color      : $gray-900 !default;
@@ -1259,7 +1259,7 @@ $card-bg                 : $white !default;
 
 $card-img-overlay-padding: $spacer !default;
 
-$card-group-margin     : $grid-gutter-width / 2 !default;
+$card-group-margin     : $grid-gutter-width * 0.5 !default;
 $transition-bezier-card: cubic-bezier(0.34, 1.45, 0.7, 1) !default;
 
 //Timelines
@@ -1473,7 +1473,7 @@ $list-group-border-radius: $border-radius !default;
 $list-group-sm-item-padding-y: .625rem !default;
 $list-group-sm-item-padding-x: .875rem !default;
 
-$list-group-item-padding-y    : $spacer / 2 !default;
+$list-group-item-padding-y    : $spacer * 0.5 !default;
 $list-group-item-padding-x    : $spacer !default;
 $list-group-item-bg-level     : -9 !default;
 $list-group-item-color-level  : 6 !default;
@@ -1512,7 +1512,7 @@ $figure-caption-color    : $gray-600 !default;
 // Breadcrumbs
 
 $breadcrumb-font-size     : null !default;
-$breadcrumb-padding-y     : $spacer / 2 !default;
+$breadcrumb-padding-y     : $spacer * 0.5 !default;
 $breadcrumb-padding-x     : $spacer !default;
 $breadcrumb-item-padding-x: .5rem !default;
 $breadcrumb-margin-bottom : 1rem !default;

--- a/src/scss/volt/components/_animations.scss
+++ b/src/scss/volt/components/_animations.scss
@@ -15,21 +15,21 @@
 
     .scale-up-#{$size} {
         &:hover {
-            transform: scale($size / 1.8);
+            transform: scale($size * 0.5555555556);
         }
     }
 
     .scale-up-hover-#{$size} {
         &:hover {
             & .scale {
-                transform: scale($size / 1.8);
+                transform: scale($size * 0.5555555556);
             }
         }
     }
 
     .scale-down-#{$size} {
         &:hover {
-            transform: scale($size / 2.5);
+            transform: scale($size * 0.4);
         }
     }
 


### PR DESCRIPTION
Fixes warnings about deprecated **/** for divisions ( see #47 ). There are still some warnings left caused by dependencies but they should be fixed in theirs respective repositories.