### PR TITLE
Fix for content shift (issue #59)

### DIFF
--- a/src/scss/volt/layout/_sidenav.scss
+++ b/src/scss/volt/layout/_sidenav.scss
@@ -18,9 +18,9 @@
 		max-width: 260px;
 	}
 
-	.nav {
+	/*.nav {
 		white-space: nowrap;
-	}
+	}*/
 
 	.nav-item {
 		&.active {


### PR DESCRIPTION
I took a look at the problem described in issue #59 and think I found the issue. It appears to be related to the white-space: nowrap value for the .nav selector. I have disabled that value for now, and so far the problem seems to be resolved. I disabled it instead of outright removing it in case it needs to be re-enabled in the future.